### PR TITLE
Fix memory leak in unsubscribe

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ export default function createBroadcast (initialState) {
 
   // remove subscription by removing the listener function
   function unsubscribe (id) {
-    listeners[id] = undefined
+    delete listeners[id]
   }
 
   return { getState, setState, subscribe, unsubscribe }


### PR DESCRIPTION
Assigning undefined doesn't remove the key from the key set for listeners
which means it was continuously growing. This also means setState is
getting increasingly slower as it needs to skip over the now deleted keys
on every setState. Instead we should use delete to remove the key.